### PR TITLE
Add -o mode that continuously prints the ignition voltage every second

### DIFF
--- a/dcdc-usb-parse.c
+++ b/dcdc-usb-parse.c
@@ -95,7 +95,11 @@ void dcdc_parse_values(unsigned char *data)
     P("timer off delay: %d", bytes2int(data[19], data[20]));
     P("timer hard off: %d", bytes2int(data[21], data[22]));
     P("version: %d.%d", ((data[23] >> 5) & 0x07), (data[23] & 0x1F));
-    
+}
+
+void dcdc_parse_ignition(unsigned char *data)
+{
+	P("%.2f", (float) data[4] * 0.1558f);
 }
 
 void dcdc_parse_cmd(unsigned char *data)

--- a/dcdc-usb.h
+++ b/dcdc-usb.h
@@ -22,6 +22,7 @@ void dcdc_parse_values(unsigned char *data);
 void dcdc_parse_cmd(unsigned char *data);
 void dcdc_parse_internal_msg(unsigned char *data);
 void dcdc_parse_mem(unsigned char *data);
+void dcdc_parse_ignition(unsigned char *data);
 
 /* from windows source with small sanity edits */
 


### PR DESCRIPTION
This is a quick and dirty patch to add a `-o` - this prints the ignition voltage every second forever.  Combined with some other scripts, this can be used to achieve poweroff without having to connect the power switch lines.